### PR TITLE
Fix all references from moshloop to flanksource

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   release:
     docker:
       - image: circleci/golang:1.12
-    working_directory: /go/src/github.com/moshloop/platform-operator
+    working_directory: /go/src/github.com/flanksource/platform-operator
     steps:
       - checkout
       - setup_remote_docker

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
 tag := $(shell git tag --points-at HEAD )
-name := "moshloop/platform-operator"
+name := "flanksource/platform-operator"
 
 ifdef tag
 else

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Platform Operator is a kubernetes operator designed to be run in a multi-tenante
 1. Installing
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/moshloop/platform-operator/master/deploy/platform-operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/flanksource/platform-operator/master/deploy/platform-operator.yaml
 ```
 
 ### Auto-Delete

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -6,8 +6,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/moshloop/platform-operator/pkg/controllers"
-	"github.com/moshloop/platform-operator/pkg/k8s"
+	"github.com/flanksource/platform-operator/pkg/controllers"
+	"github.com/flanksource/platform-operator/pkg/k8s"
 )
 
 var watchInterval string

--- a/deploy/platform-operator.yaml
+++ b/deploy/platform-operator.yaml
@@ -37,6 +37,6 @@ spec:
       serviceAccountName: platform-operator
       containers:
         - name: platform-operator
-          image: docker.io/moshloop/platform-operator:0.1
+          image: docker.io/flanksource/platform-operator:0.1
           command:
             - /platform-operator serve -watch-interval 5m

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/moshloop/platform-operator
+module github.com/flanksource/platform-operator
 
 go 1.12
 

--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ package main
 import (
 	"fmt"
 	"os"
-	"github.com/moshloop/platform-operator/cmd"
+	"github.com/flanksource/platform-operator/cmd"
 
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
This commit replaces all the references from `moshloop` git repository to `flanksource`.

Closes #6 